### PR TITLE
Bugfix/libcrypto

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,37 +149,29 @@ jobs:
         shell: bash
         working-directory: aseprite
         run: ninja -C build
-
-      - name: Build OpenSSL (shared mode)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          Invoke-WebRequest -Uri https://www.openssl.org/source/openssl-1.1.1w.tar.gz -OutFile openssl.tar.gz
-          tar -xzf openssl.tar.gz
-          cd openssl-1.1.1w
-      
-          # Set up MSVC environment
-          $vcvars = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
-          if (-Not (Test-Path $vcvars)) {
-            throw "Could not find vcvars64.bat"
-          }
-      
-          # Configure OpenSSL in shared mode
-          cmd /c "`"$vcvars`" && perl Configure VC-WIN64A shared && nmake && nmake install"
-      
-          # Find installed DLLs
-          $dlls = Get-ChildItem -Recurse -Filter *.dll | Where-Object { $_.Name -like "libcrypto*" -or $_.Name -like "libssl*" }
-      
-          # Copy DLLs into Aseprite bin folder
-          foreach ($dll in $dlls) {
-            Copy-Item $dll.FullName -Destination ../aseprite/build/bin -Force
-          }
-
         
       - name: Clean Up Build folder
         shell: bash
         working-directory: aseprite/build/bin
         run: find . -mindepth 1 ! \( -name 'aseprite' -o -name 'aseprite.exe' -o -name 'data' -prune \) -exec rm -rf {} +
+
+      - name: Download and extract OpenSSL DLLs (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        working-directory: aseprite/build/bin
+        run: |
+          # Download the zip from https://wiki.overbyte.eu/wiki/index.php/ICS_Download
+          # This binary provider comes from a suggested 3rd party list on the official opensll github
+          Invoke-WebRequest -Uri "https://wiki.overbyte.eu/arch/openssl-1.0.2u-win64.zip" -OutFile dlls.zip
+          
+          # Extract dlls into same path as the .exe
+          Expand-Archive -Path dlls.zip -DestinationPath temp_dlls
+          Copy-Item temp_dlls\libcrypto-1_1-x64.dll .
+          Copy-Item temp_dlls\libssl-1_1-x64.dll .
+
+          # Remove the ssl zip + temp folder from the final release
+          Remove-Item -Recurse -Force temp_dlls
+          Remove-Item dlls.zip
 
       - name: Make portable zip
         working-directory: aseprite/build/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,15 +150,32 @@ jobs:
         working-directory: aseprite
         run: ninja -C build
 
-      - name: Download OpenSSL DLLs (Windows)
+      - name: Build OpenSSL (shared mode)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Invoke-WebRequest -Uri https://slproweb.com/download/Win64OpenSSL-1_1_1w.exe -OutFile openssl.exe
-          Start-Process .\openssl.exe -ArgumentList '/silent', '/verysilent', '/dir=C:\OpenSSL-Win64' -Wait
-          Copy-Item 'C:\OpenSSL-Win64\bin\libcrypto-1_1-x64.dll' -Destination 'aseprite/build/bin'
-          Copy-Item 'C:\OpenSSL-Win64\bin\libssl-1_1-x64.dll' -Destination 'aseprite/build/bin'
+          Invoke-WebRequest -Uri https://www.openssl.org/source/openssl-1.1.1w.tar.gz -OutFile openssl.tar.gz
+          tar -xzf openssl.tar.gz
+          cd openssl-1.1.1w
+      
+          # Set up MSVC environment
+          $vcvars = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+          if (-Not (Test-Path $vcvars)) {
+            throw "Could not find vcvars64.bat"
+          }
+      
+          # Configure OpenSSL in shared mode
+          cmd /c "`"$vcvars`" && perl Configure VC-WIN64A shared && nmake && nmake install"
+      
+          # Find installed DLLs
+          $dlls = Get-ChildItem -Recurse -Filter *.dll | Where-Object { $_.Name -like "libcrypto*" -or $_.Name -like "libssl*" }
+      
+          # Copy DLLs into Aseprite bin folder
+          foreach ($dll in $dlls) {
+            Copy-Item $dll.FullName -Destination ../aseprite/build/bin -Force
+          }
 
+        
       - name: Clean Up Build folder
         shell: bash
         working-directory: aseprite/build/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,15 @@ jobs:
         working-directory: aseprite
         run: ninja -C build
 
+      - name: Download OpenSSL DLLs (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri https://slproweb.com/download/Win64OpenSSL-1_1_1w.exe -OutFile openssl.exe
+          Start-Process .\openssl.exe -ArgumentList '/silent', '/verysilent', '/dir=C:\OpenSSL-Win64' -Wait
+          Copy-Item 'C:\OpenSSL-Win64\bin\libcrypto-1_1-x64.dll' -Destination 'aseprite/build/bin'
+          Copy-Item 'C:\OpenSSL-Win64\bin\libssl-1_1-x64.dll' -Destination 'aseprite/build/bin'
+
       - name: Clean Up Build folder
         shell: bash
         working-directory: aseprite/build/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           # Download the zip from https://wiki.overbyte.eu/wiki/index.php/ICS_Download
           # This binary provider comes from a suggested 3rd party list on the official opensll github
-          Invoke-WebRequest -Uri "https://wiki.overbyte.eu/arch/openssl-1.0.2u-win64.zip" -OutFile dlls.zip
+          Invoke-WebRequest -Uri "https://wiki.overbyte.eu/arch/openssl-1.1.1w-win64.zip" -OutFile dlls.zip
           
           # Extract dlls into same path as the .exe
           Expand-Archive -Path dlls.zip -DestinationPath temp_dlls


### PR DESCRIPTION
Builds for windows platform were encountering an issue with missing .dll, added a step to pipeline to download the binaries and include in the windows release